### PR TITLE
Fixcolors

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!-- Navigation-->
-<nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
+<nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
     <div class="container px-4 px-lg-5">
         <a class="navbar-brand" href="#page-top"><img src="{{ .Site.Params.logo }}"></a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -4604,7 +4604,7 @@ textarea.form-control-lg {
 }
 .navbar-dark .navbar-nav .show > .nav-link,
 .navbar-dark .navbar-nav .nav-link.active {
-  color: #fff;
+  color: #64a19d;
 }
 .navbar-dark .navbar-toggler {
   color: rgba(255, 255, 255, 0.55);

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -4559,7 +4559,7 @@ textarea.form-control-lg {
   color: rgba(0, 0, 0, 0.9);
 }
 .navbar-light .navbar-nav .nav-link {
-  color: #fff;
+  color: rgba(0, 0, 0, 0.55);
 }
 .navbar-light .navbar-nav .nav-link:hover, .navbar-light .navbar-nav .nav-link:focus {
   color: rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
Hello
Active and hover navigation links colors in compact mode looks broken
![image](https://user-images.githubusercontent.com/51533848/213618888-1f179884-3b86-4bc3-95cc-1be31968f823.png)

There is special class navbar-dark for dark navigation bars.

I have changed navbar-light to dark and original active link color.
![image](https://user-images.githubusercontent.com/51533848/213619116-f320c7d2-f105-4891-94ce-1db7c766343a.png)
